### PR TITLE
settings: Add support for optional settings_local.py config file

### DIFF
--- a/open_grgraz/settings.py
+++ b/open_grgraz/settings.py
@@ -135,3 +135,9 @@ ADMINS = [
         'petertheone@gmail.com',
     ),
 ]
+
+# Use the file local_settings.py to overwrite the defaults with your own settings
+try:
+    from open_grgraz.settings_local import *
+except ImportError:
+    pass


### PR DESCRIPTION
Does what it says on the tin.

Fügt einen optionalen Import für settings_local.py ans Ende von settings.py hinzu. Nützlich für Deployment-/Produktionsettings.